### PR TITLE
Enable VoWiFi for Telekom.de

### DIFF
--- a/overlay/CarrierConfig/packages/apps/CarrierConfig/res/xml/vendor.xml
+++ b/overlay/CarrierConfig/packages/apps/CarrierConfig/res/xml/vendor.xml
@@ -1583,9 +1583,13 @@
 
     <carrier_config mcc="262" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_vt_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
     </carrier_config>
 
     <carrier_config mcc="262" mnc="06">
-        <boolean name="carrier_volte_available_bool" value="true" />        
+        <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_vt_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />       
     </carrier_config>
 </carrier_config_list>


### PR DESCRIPTION
Might still have to do the EFS modding. 

See: https://forum.xda-developers.com/oneplus-5t/how-to/guide-volte-vowifi-german-carriers-t3817542